### PR TITLE
Add change_output_type to StreamDeserializer

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1248,6 +1248,17 @@ pub struct StreamDeserializer<'de, R, T> {
     lifetime: PhantomData<&'de ()>,
 }
 
+impl<'de, R, T> StreamDeserializer<'de, R, T> {
+    /// Changes ouptut type of the stream deserializer
+    pub fn change_output_type<U>(self) -> StreamDeserializer<'de, R, U> {
+        StreamDeserializer {
+            de: self.de,
+            output: PhantomData,
+            lifetime: PhantomData,
+        }
+    }
+}
+
 impl<'de, R, T> StreamDeserializer<'de, R, T>
 where
     R: Read<'de>,


### PR DESCRIPTION
## Summary

Adds a `change_output_type` method to `StreamDeserializer` that lets you switch the deserialization target type without rebuilding the deserializer or losing your position in the stream.

## Motivation

When reading a CBOR stream that contains a mix of different types (e.g. a header followed by a sequence of records), you currently have to create a new `StreamDeserializer` for each type you want to read. Since the `T` parameter on `StreamDeserializer` is only used as a `PhantomData` marker, there's no reason you shouldn't be able to swap it out on the fly.

This comes up in practice when you have a framed protocol or file format where different sections of the stream have different schemas. Without this, you end up having to drop down to `serde_cbor_2::Value` and convert manually, or do awkward workarounds with the reader.